### PR TITLE
update .gitmodules to point to correct submodule urls

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,12 +1,12 @@
 [submodule "scamp"]
 	path = submodules/scamp
-	url = ./scamp
+	url = git@github.com:astromatic/scamp.git
 [submodule "sextractor"]
 	path = submodules/sextractor
-	url = ./sextractor/
+	url = git@github.com:astromatic/sextractor.git	
 [submodule "swarp"]
 	path = submodules/swarp
-	url = ./swarp
+	url = git@github.com:astromatic/swarp.git		
 [submodule "hotpants"]
 	path = submodules/hotpants
-	url = ./hotpants/
+	url = git@github.com:acbecker/hotpants.git


### PR DESCRIPTION
Submodule paths were specified relative to ./, this points them to the remote git repositories so that folks who clone the repository can also clone the submodule data. 