### PR TITLE
add black and flake8 to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
 pre-commit==2.9.3
+black==19.10b0
+flake8==3.7.9


### PR DESCRIPTION
These are required for #8 but neglected to add these as the CI is not up and running yet. 